### PR TITLE
Add tests of treatment of NULL values

### DIFF
--- a/inst/tests/test-toJSON-NULL-values.R
+++ b/inst/tests/test-toJSON-NULL-values.R
@@ -1,0 +1,19 @@
+context("toJSON NULL values")
+
+test_that("Test NULL values", {
+  x <- NULL
+  y <- list(a=NULL, b=NA)
+  z <- list(a=1, b=character(0))
+
+  expect_that(validate(toJSON(x)), is_true())
+  expect_that(toJSON(x), equals("{}"))
+  expect_that(fromJSON(toJSON(x)), equals(list()))
+
+  expect_that(validate(toJSON(y)), is_true())
+  expect_that(gsub("\\s", "", toJSON(y)), equals("{\"a\":{},\"b\":[null]}"))
+  expect_that(fromJSON(toJSON(y)), equals(list(a=list(), b=NA)))
+
+  expect_that(validate(toJSON(z)), is_true())
+  expect_that(gsub("\\s", "", toJSON(z)), equals("{\"a\":[1],\"b\":[]}"))
+  expect_that(fromJSON(toJSON(z)), equals(list(a=1, b=list())))
+});


### PR DESCRIPTION
I was a bit surprised by the treatment of `NULL` values.

I thought it'd be useful to document the behavior in some tests.

I included the case that @yihui [tweeted](https://twitter.com/xieyihui/status/462342867818532864), in which the latest version of [RJSONIO](https://github.com/duncantl/RJSONIO) gives a bad result:

```
list(a=1, b=character(0))
```
