### PR TITLE
Add trailing newline to JSON print

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -1,7 +1,7 @@
 #' @method print json
 #' @export
 print.json <- function(x, ...){
-  cat(x)
+  cat(x, "\n")
 }
 
 #' @method print scalar


### PR DESCRIPTION
It is not needed in RStudio, becuse that
adds a newline before putting out a prompt. It is
needed in console R and Emacs, etc.

Before:

``` r
> jsonlite::toJSON(1:4)
[1,2,3,4]> 
```

After:

``` r
> toJSON(1:4)
[1,2,3,4] 
> 
```
