### PR TITLE
Build on @wch's work with a faster escaper

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -30,3 +30,5 @@ src/Makevars$
 ^tidy.R$
 ^.travis.yml$
 paper$
+^.*\.pro$
+^.*\.pro\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ vignettes/framed.sty
 vignettes/.DS_Store
 .DS_Store
 
-
+*.pro.user

--- a/jsonlite.pro
+++ b/jsonlite.pro
@@ -1,0 +1,14 @@
+TEMPLATE = app
+CONFIG += console
+CONFIG -= app_bundle
+CONFIG -= qt
+
+## R includes (call devtools::use_qtcreator() to update)
+INCLUDEPATH += /Library/Frameworks/R.framework/Resources/include
+INCLUDEPATH += $$PWD/inst/include
+
+HEADERS += src/*.h
+HEADERS += src/*.hpp
+
+SOURCES += src/*.c
+SOURCES += src/*.cpp


### PR DESCRIPTION
This avoids the initial runthrough counting matches to allocate an exact length, and instead overallocates up to the maximum possible length. Testing shows this to be ~1.5x faster (but this may not be worth the memory overhead?)

With the benchmarking code:

``` R
# Create vector with random strings
mychars <- c(letters, " ", '"', "\\", "\t", "\n", "\r", "'", "/", "#", "$");
createstring <- function(length){
  paste(mychars[ceiling(runif(length, 0, length(mychars)))], collapse="")
}
strings <- vapply(rep(1000, 10000), createstring, character(1), USE.NAMES=FALSE)
```

I see, with master:

```
system.time(.Call(jsonlite:::C_escape_chars, strings))
 user  system elapsed 
0.152   0.004   0.162 
```

and on this branch:

```
> system.time(.Call(jsonlite:::C_escape_chars, strings))
   user  system elapsed 
  0.111   0.006   0.117
```

but we are paying a lot for the extra memory. (Maybe it would be worth delegating to this as an optimization for smaller strings?)
