### PR TITLE
rename const power 10

### DIFF
--- a/src/modp_numtoa.c
+++ b/src/modp_numtoa.c
@@ -19,7 +19,7 @@
  * Powers of 10
  * 10^0 to 10^9
  */
-static const double pow10[] = {1, 10, 100, 1000, 10000, 100000, 1000000,
+static const double poww10[] = {1, 10, 100, 1000, 10000, 100000, 1000000,
                                10000000, 100000000, 1000000000};
 
 static void strreverse(char* begin, char* end)
@@ -112,14 +112,14 @@ void modp_dtoa(double value, char* str, int prec)
 
 
     int whole = (int) value;
-    double tmp = (value - whole) * pow10[prec];
+    double tmp = (value - whole) * poww10[prec];
     uint32_t frac = (uint32_t)(tmp);
     diff = tmp - frac;
 
     if (diff > 0.5) {
         ++frac;
         /* handle rollover, e.g.  case 0.99 with prec 1 is 1.0  */
-        if (frac >= pow10[prec]) {
+        if (frac >= poww10[prec]) {
             frac = 0;
             ++whole;
         }
@@ -214,14 +214,14 @@ void modp_dtoa2(double value, char* str, int prec)
 
 
     int whole = (int) value;
-    double tmp = (value - whole) * pow10[prec];
+    double tmp = (value - whole) * poww10[prec];
     uint32_t frac = (uint32_t)(tmp);
     diff = tmp - frac;
 
     if (diff > 0.5) {
         ++frac;
         /* handle rollover, e.g.  case 0.99 with prec 1 is 1.0  */
-        if (frac >= pow10[prec]) {
+        if (frac >= poww10[prec]) {
             frac = 0;
             ++whole;
         }


### PR DESCRIPTION
In windows Cygwin 32, the compiling fails and reports:

``` bash
modp_numtoa.c:22:21: error: ‘pow10’ redeclared as different kind of symbol
 static const double pow10[] = {1, 10, 100, 1000, 10000, 100000, 1000000,
                     ^
/usr/lib/R/etc/Makeconf:123: recipe for target 'modp_numtoa.o' failed
make: *** [modp_numtoa.o] Error 1
ERROR: compilation failed for package ‘jsonlite’
* removing ‘/usr/lib/R/site-library/jsonlite’
```

Rename the const array will avoid such error.
