### PR TITLE
Remove View override in RStudio > 0.99.324

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,6 +6,8 @@ License: MIT + file LICENSE
 NeedsCompilation: yes
 Depends:
     methods
+Imports:
+    rstudioapi (>= 0.2)
 Author: Jeroen Ooms, Duncan Temple Lang, Lloyd Hilaiel
 URL: http://arxiv.org/abs/1403.2805,
     https://www.opencpu.org/posts/jsonlite-a-smarter-json-encoder

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,8 +6,6 @@ License: MIT + file LICENSE
 NeedsCompilation: yes
 Depends:
     methods
-Imports:
-    rstudioapi (>= 0.2)
 Author: Jeroen Ooms, Duncan Temple Lang, Lloyd Hilaiel
 URL: http://arxiv.org/abs/1403.2805,
     https://www.opencpu.org/posts/jsonlite-a-smarter-json-encoder

--- a/R/init.R
+++ b/R/init.R
@@ -1,0 +1,9 @@
+.onAttach <- function(lib, pkg) {
+  # remove View override in newer versions of RStudio, which can handle nested
+  # frames natively
+  if (rstudioapi::isAvailable("0.99.324")) {
+    unlockBinding("View", as.environment("package:jsonlite"))
+    assign("View", get("View", "package:utils"), "package:jsonlite")
+    lockBinding("View", as.environment("package:jsonlite"))
+  }
+}

--- a/R/init.R
+++ b/R/init.R
@@ -1,9 +1,11 @@
 .onAttach <- function(lib, pkg) {
   # remove View override in newer versions of RStudio, which can handle nested
-  # frames natively
-  if (rstudioapi::isAvailable("0.99.324")) {
-    unlockBinding("View", as.environment("package:jsonlite"))
-    assign("View", get("View", "package:utils"), "package:jsonlite")
-    lockBinding("View", as.environment("package:jsonlite"))
+  # frames natively; take no action if rstudioapi isn't present
+  rstudioapi <- "rstudioapi"
+  if (requireNamespace(rstudioapi, quietly = TRUE)) {
+    isAvailable <- get("isAvailable", envir = asNamespace(rstudioapi))
+    if (isAvailable("0.99.324")) {
+      assign("View", get("View", "package:utils"), "package:jsonlite")
+    }
   }
 }


### PR DESCRIPTION
This change replaces jsonlite's `View` override with the RStudio default `View` when the following are all true:

- The rstudioapi package is installed
- The rstudioapi package indicates that RStudio is running
- The rstudioapi package indicates that the running version of RStudio is at least 0.99.324 

Older versions of RStudio, or non-RStudio environments, will continue to have an overridden `View`. 