### PR TITLE
Add asJSON method for AsIs objects

### DIFF
--- a/R/asJSON.AsIs.R
+++ b/R/asJSON.AsIs.R
@@ -1,0 +1,14 @@
+setOldClass("AsIs")
+setMethod("asJSON", "AsIs", function(x, auto_unbox = FALSE, ...) {
+
+  # Strip off the AsIs class so we can dispatch to other asJSON methods.
+  class(x) <- setdiff(class(x), "AsIs")
+
+  if (is.atomic(x) && length(x) == 1) {
+    # Never auto_unbox single values when wrapped with I()
+    asJSON(x, auto_unbox = FALSE, ...)
+
+  } else {
+    asJSON(x, auto_unbox = auto_unbox, ...)
+  }
+})

--- a/R/fromJSON.R
+++ b/R/fromJSON.R
@@ -35,6 +35,7 @@
 #' @param null how to encode NULL values within a list: must be one of 'null' or 'list'
 #' @param na how to print NA values: must be one of 'null' or 'string'. Defaults are class specific
 #' @param auto_unbox automatically \code{\link{unbox}} all atomic vectors of length 1. It is usually safer to avoid this and instead use the \code{\link{unbox}} function to unbox individual elements.
+#'   An exception is that objects of class \code{AsIs} (i.e. wrapped in \code{I()}) are not automatically unboxed. This is a way to mark single values as length-1 arrays.
 #' @param digits max number of decimal digits to print for numeric values. Use \code{I()} to specify significant digits.
 #' @param force unclass/skip objects of classes with no defined JSON mapping
 #' @param pretty adds indentation whitespace to JSON output. Can be TRUE/FALSE or a number specifying the number of spaces to indent. See \code{\link{prettify}}

--- a/inst/tests/test-toJSON-AsIs.R
+++ b/inst/tests/test-toJSON-AsIs.R
@@ -1,0 +1,14 @@
+context("toJSON AsIs")
+
+test_that("Encoding AsIs", {
+  expect_that(toJSON(list(1), auto_unbox=TRUE), equals("[1]"));
+  expect_that(toJSON(list(I(1)), auto_unbox=TRUE), equals("[[1]]"));
+  expect_that(toJSON(I(list(1)), auto_unbox=TRUE), equals("[1]"));
+
+  expect_that(toJSON(list(x=1)), equals("{\"x\":[1]}"));
+  expect_that(toJSON(list(x=1), auto_unbox=TRUE), equals("{\"x\":1}"));
+  expect_that(toJSON(list(x=I(1)), auto_unbox=TRUE), equals("{\"x\":[1]}"));
+
+  expect_that(toJSON(list(x=I(list(1))), auto_unbox=TRUE), equals("{\"x\":[1]}"));
+  expect_that(toJSON(list(x=list(I(1))), auto_unbox=TRUE), equals("{\"x\":[[1]]}"));
+});

--- a/man/fromJSON.Rd
+++ b/man/fromJSON.Rd
@@ -50,7 +50,8 @@ toJSON(x, dataframe = c("rows", "columns", "values"), matrix = c("rowmajor",
 
 \item{na}{how to print NA values: must be one of 'null' or 'string'. Defaults are class specific}
 
-\item{auto_unbox}{automatically \code{\link{unbox}} all atomic vectors of length 1. It is usually safer to avoid this and instead use the \code{\link{unbox}} function to unbox individual elements.}
+\item{auto_unbox}{automatically \code{\link{unbox}} all atomic vectors of length 1. It is usually safer to avoid this and instead use the \code{\link{unbox}} function to unbox individual elements.
+An exception is that objects of class \code{AsIs} (i.e. wrapped in \code{I()}) are not automatically unboxed. This is a way to mark single values as length-1 arrays.}
 
 \item{digits}{max number of decimal digits to print for numeric values. Use \code{I()} to specify significant digits.}
 


### PR DESCRIPTION
This fixes #78.

When `auto_unbox=TRUE`, this tells `asJSON` to not automatically unbox length-1 vectors when they have class `AsIs` -- that is, when they are wrapped in `I()`. This mimics the behavior of RJSONIO.

For example, with this patch:

```R
# This is unchanged from before
jsonlite::toJSON(list(x = "text"), auto_unbox = TRUE)
# {"x":"text"} 

# Don't unbox single values when wrapped in I()
jsonlite::toJSON(list(x = I("text")), auto_unbox = TRUE)
# {"x":["text"]} 
```

This change shouldn't have any effect when `auto_unbox=FALSE`.

Let me know if you have any comments or concerns.