### PR TITLE
When auto_unbox=TRUE make sure length-1 atomic vectors are in []. Fixes #71

### DIFF
--- a/R/toJSON.R
+++ b/R/toJSON.R
@@ -30,6 +30,11 @@ toJSON <- function(x, dataframe = c("rows", "columns", "values"), matrix = c("ro
     na <- NULL
   }
 
+  # Make sure that length-1 atomic vectors are in [], even when auto_unbox is TRUE
+  if (auto_unbox && length(x) == 1 && (is.atomic(x) || inherits(x, "POSIXt"))) {
+    auto_unbox <- FALSE
+  }
+
   # dispatch
   ans <- asJSON(x, dataframe = dataframe, Date = Date, POSIXt = POSIXt, factor = factor,
     complex = complex, raw = raw, matrix = matrix, auto_unbox = auto_unbox, digits = digits,

--- a/inst/tests/test-toJSON-auto-unbox.R
+++ b/inst/tests/test-toJSON-auto-unbox.R
@@ -1,0 +1,32 @@
+context("toJSON auto_unbox")
+
+test_that("auto_unbox with vectors", {
+  # Special case - a length-1 atomic vector - should not be unboxed
+  expect_that(toJSON(1, auto_unbox=TRUE), equals("[1]"));
+  expect_that(toJSON(list(1), auto_unbox=TRUE), equals("[1]"));
+
+  # Test other types
+  expect_that(toJSON(as.POSIXct('2015-01-01 03:00:00'), auto_unbox=TRUE), equals('["2015-01-01 03:00:00"]'));
+  expect_that(toJSON(as.POSIXlt('2015-01-01 03:00:00'), auto_unbox=TRUE), equals('["2015-01-01 03:00:00"]'));
+
+  expect_that(toJSON(1:3, auto_unbox=TRUE), equals("[1,2,3]"));
+  expect_that(toJSON(list(1:3), auto_unbox=TRUE), equals("[[1,2,3]]"));
+});
+
+test_that("auto_unbox with matrices", {
+  # 1x1 matrices should still be in [[]]
+  expect_that(toJSON(matrix(1), auto_unbox=TRUE), equals("[[1]]"));
+}
+
+test_that("auto_unbox with data frames", {
+  df <- data.frame(x=1:2, y=3:4)
+
+  # 1-row data frames in column format shouldn't be unboxed
+  expect_that(toJSON(df[1,], auto_unbox=TRUE, dataframe = 'columns'), equals('{"x":[1],"y":[3]}'));
+  expect_that(toJSON(df, auto_unbox=TRUE, dataframe = 'columns'), equals('{"x":[1,2],"y":[3,4]}'));
+});
+
+test_that("auto_unbox with lists", {
+  expect_that(toJSON(list(x=1, y=3), auto_unbox=TRUE), equals('{"x":1,"y":3}'));
+  expect_that(toJSON(list(x=c(1,2), y=c(3,4)), auto_unbox=TRUE), equals('{"x":[1,2],"y":[3,4]}'));
+});


### PR DESCRIPTION
This PR fixes #71.

A couple notes and questions:

* `POSIXlt` objects get FALSE for `is.atomic()`, hence the explicit check for `POSIXt`. But the `is.atomic()` check appears a number of times in the jsonlite code - perhaps there should be a wrapper function that checks for atomic or POSIXt? I think all the other types that should be treated as atomic in jsonlite get TRUE for `is.atomic()`, but I'm not completely sure.
* Is the `;` at the end of lines in tests intentional? I copied that style from other tests.
