### PR TITLE
Add keep_vec_names option for converting named vectors to JSON objects

### DIFF
--- a/R/asJSON.character.R
+++ b/R/asJSON.character.R
@@ -1,4 +1,5 @@
-setMethod("asJSON", "character", function(x, collapse = TRUE, na = c("null", "string", "NA"), auto_unbox = FALSE, ...) {
+setMethod("asJSON", "character", function(x, collapse = TRUE, na = c("null", "string", "NA"),
+  auto_unbox = FALSE, ..., keep_vec_names = FALSE) {
 
   # vectorized escaping
   tmp <- deparse_vector(x)
@@ -20,6 +21,11 @@ setMethod("asJSON", "character", function(x, collapse = TRUE, na = c("null", "st
     } else {
       tmp[missings] <- NA_character_
     }
+  }
+
+  if (isTRUE(keep_vec_names) && !is.null(names(x))) {
+    warn_keep_vec_names()
+    return(asJSON(as.list(x), collapse = collapse, na = na, auto_unbox = TRUE, ...))
   }
 
   if(isTRUE(auto_unbox) && length(tmp) == 1){

--- a/R/asJSON.factor.R
+++ b/R/asJSON.factor.R
@@ -1,4 +1,6 @@
-setMethod("asJSON", "factor", function(x, factor = c("string", "integer"), ...) {
+setMethod("asJSON", "factor", function(x, factor = c("string", "integer"), ...,
+  keep_vec_names = FALSE) {
+
   # validate
   factor <- match.arg(factor)
 
@@ -6,8 +8,16 @@ setMethod("asJSON", "factor", function(x, factor = c("string", "integer"), ...) 
   if (factor == "integer") {
     # encode factor as enum
     asJSON(unclass(x), ...)
+
   } else {
+    xc <- as.character(x)
+
+    if (isTRUE(keep_vec_names) && !is.null(names(x))) {
+      # as.character drops names, so we need to explicitly keep them
+      names(xc) <- names(x)
+    }
+
     # encode as strings
-    asJSON(as.character(x), ...)
+    asJSON(xc, keep_vec_names = keep_vec_names, ...)
   }
 })

--- a/R/asJSON.logical.R
+++ b/R/asJSON.logical.R
@@ -1,4 +1,6 @@
-setMethod("asJSON", "logical", function(x, collapse = TRUE, na = c("null", "string", "NA"), auto_unbox = FALSE, ...) {
+setMethod("asJSON", "logical", function(x, collapse = TRUE,
+  na = c("null", "string", "NA"), auto_unbox = FALSE, ..., keep_vec_names = FALSE) {
+
   # validate arg
   na <- match.arg(na)
 
@@ -16,6 +18,11 @@ setMethod("asJSON", "logical", function(x, collapse = TRUE, na = c("null", "stri
   #this is needed when !length(tmp) or all(is.na(tmp))
   if(!is.character(tmp)){
     tmp <- as.character(tmp);
+  }
+
+  if (isTRUE(keep_vec_names) && !is.null(names(x))) {
+    warn_keep_vec_names()
+    return(asJSON(as.list(x), collapse = collapse, na = na, auto_unbox = TRUE, ...))
   }
 
   if(isTRUE(auto_unbox) && length(tmp) == 1){

--- a/R/asJSON.numeric.R
+++ b/R/asJSON.numeric.R
@@ -1,5 +1,6 @@
 setMethod("asJSON", "numeric", function(x, digits = 5, use_signif = is(digits, "AsIs"),
-  na = c("string", "null", "NA"), auto_unbox = FALSE, collapse = TRUE, ...) {
+  na = c("string", "null", "NA"), auto_unbox = FALSE, collapse = TRUE,
+  ..., keep_vec_names = FALSE) {
 
   na <- match.arg(na);
   na_as_string <- switch(na,
@@ -11,6 +12,12 @@ setMethod("asJSON", "numeric", function(x, digits = 5, use_signif = is(digits, "
 
   # old R implementation
   # tmp <- num_to_char_R(x, digits, na_as_string);
+
+  if (isTRUE(keep_vec_names) && !is.null(names(x))) {
+    warn_keep_vec_names()
+    return(asJSON(as.list(x), digits = digits, use_signif = use_signif, na = na,
+      auto_unbox = TRUE, collapse = collapse, ...))
+  }
 
   # fast C implementation
   tmp <- if(is(x, "integer64")){

--- a/R/fromJSON.R
+++ b/R/fromJSON.R
@@ -39,6 +39,10 @@
 #' @param digits max number of decimal digits to print for numeric values. Use \code{I()} to specify significant digits.
 #' @param force unclass/skip objects of classes with no defined JSON mapping
 #' @param pretty adds indentation whitespace to JSON output. Can be TRUE/FALSE or a number specifying the number of spaces to indent. See \code{\link{prettify}}
+#' @param keep_vec_names if \code{FALSE} (the default), named vectors will be converted to JSON arrays, dropping names.
+#'   If \code{TRUE}, they will be converted to JSON objects (with names), similar to named lists.
+#'   The \code{TRUE} setting is only for backward compatibility with RJSONIO, and a message will be printed each time a named vector is encountered.
+#'   This option will stop being supported in a future version of jsonlite.
 #' @param ... arguments passed on to class specific \code{print} methods
 #' @references Jeroen Ooms (2014). The \code{jsonlite} Package: A Practical and Consistent Mapping Between JSON Data and \R{} Objects. \emph{arXiv:1403.2805}. \url{http://arxiv.org/abs/1403.2805}
 #' @examples # Stringify some data

--- a/R/toJSON.R
+++ b/R/toJSON.R
@@ -3,7 +3,7 @@ toJSON <- function(x, dataframe = c("rows", "columns", "values"), matrix = c("ro
   Date = c("ISO8601", "epoch"), POSIXt = c("string", "ISO8601", "epoch", "mongo"),
   factor = c("string", "integer"), complex = c("string", "list"), raw = c("base64", "hex", "mongo"),
   null = c("list", "null"), na = c("null", "string"), auto_unbox = FALSE, digits = 4,
-  pretty = FALSE, force = FALSE, ...) {
+  pretty = FALSE, force = FALSE, keep_vec_names = FALSE, ...) {
 
   # validate args
   dataframe <- match.arg(dataframe)
@@ -33,7 +33,7 @@ toJSON <- function(x, dataframe = c("rows", "columns", "values"), matrix = c("ro
   # dispatch
   ans <- asJSON(x, dataframe = dataframe, Date = Date, POSIXt = POSIXt, factor = factor,
     complex = complex, raw = raw, matrix = matrix, auto_unbox = auto_unbox, digits = digits,
-    na = na, null = null, force = force, ...)
+    na = na, null = null, force = force, keep_vec_names = keep_vec_names, ...)
 
   #prettify
   if (isTRUE(pretty)) {

--- a/R/warn_keep_vec_names.R
+++ b/R/warn_keep_vec_names.R
@@ -1,0 +1,6 @@
+warn_keep_vec_names <- function() {
+  message("Input to asJSON(keep_vec_names=TRUE) is a named vector. ",
+    "In a future version of jsonlite, this option will not be supported, ",
+    "and named vectors will be translated into arrays instead of objects. ",
+    "If you want JSON object output, please use a named list instead. See ?toJSON.")
+}

--- a/inst/tests/test-toJSON-keep-vec-names.R
+++ b/inst/tests/test-toJSON-keep-vec-names.R
@@ -1,0 +1,39 @@
+context("toJSON keep_vec_names")
+
+test_that("keep_vec_names with named vectors", {
+  toJSON2 <- function(x) {
+    toJSON(x, keep_vec_names = TRUE, auto_unbox = TRUE)
+  }
+
+  # Basic types should give messages
+  # Length-1 vectors
+  expect_message(expect_equal(toJSON2(c(a=1)), '{"a":1}'))
+  expect_message(expect_equal(toJSON2(c(a="x")), '{"a":"x"}'))
+  expect_message(expect_equal(toJSON2(c(a=TRUE)), '{"a":true}'))
+
+  # Longer vectors
+  expect_message(expect_equal(toJSON2(c(a=1,b=2)), '{"a":1,"b":2}'))
+  expect_message(expect_equal(toJSON2(c(a="x",b="y")), '{"a":"x","b":"y"}'))
+  expect_message(expect_equal(toJSON2(c(a=FALSE,b=TRUE)), '{"a":false,"b":true}'))
+
+  # Some other types
+  expect_message(expect_equal(toJSON2(factor(c(a="x"))), '{"a":"x"}'))
+  expect_message(expect_equal(toJSON2(c(a=as.Date("2015-01-01"))), '{"a":"2015-01-01"}'))
+  expect_message(expect_equal(toJSON2(c(a=as.POSIXct("2015-01-01 3:00:00"))), '{"a":"2015-01-01 03:00:00"}'))
+  expect_message(expect_equal(toJSON2(c(a=as.POSIXlt("2015-01-01 3:00:00"))), '{"a":"2015-01-01 03:00:00"}'))
+
+  # keep_vec_names shouldn't affect unnamed vectors
+  expect_equal(toJSON2(1), '1')
+  expect_equal(toJSON2(c(1:3)), '[1,2,3]')
+}
+
+
+# Data frames generally don't allow named columns, except in very unusual cases
+test_that("keep_vec_names with data frames", {
+  toJSON2 <- function(x) {
+    toJSON(x, keep_vec_names = TRUE, auto_unbox = TRUE, dataframe = "columns", rownames = FALSE)
+  }
+
+  expect_equal(toJSON2(data.frame(x=c(a=1), y=2)), '{"x":[1],"y":[2]}')
+  expect_equal(toJSON2(data.frame(x=c(a=1,b=2), y=c(c=3,d=4))), '{"x":[1,2],"y":[3,4]}')
+}

--- a/man/fromJSON.Rd
+++ b/man/fromJSON.Rd
@@ -15,7 +15,8 @@ toJSON(x, dataframe = c("rows", "columns", "values"), matrix = c("rowmajor",
   "ISO8601", "epoch", "mongo"), factor = c("string", "integer"),
   complex = c("string", "list"), raw = c("base64", "hex", "mongo"),
   null = c("list", "null"), na = c("null", "string"), auto_unbox = FALSE,
-  digits = 4, pretty = FALSE, force = FALSE, ...)
+  digits = 4, pretty = FALSE, force = FALSE, keep_vec_names = FALSE,
+  ...)
 }
 \arguments{
 \item{txt}{a JSON string, URL or file}
@@ -58,6 +59,11 @@ An exception is that objects of class \code{AsIs} (i.e. wrapped in \code{I()}) a
 \item{pretty}{adds indentation whitespace to JSON output. Can be TRUE/FALSE or a number specifying the number of spaces to indent. See \code{\link{prettify}}}
 
 \item{force}{unclass/skip objects of classes with no defined JSON mapping}
+
+\item{keep_vec_names}{if \code{FALSE} (the default), named vectors will be converted to JSON arrays, dropping names.
+If \code{TRUE}, they will be converted to JSON objects (with names), similar to named lists.
+The \code{TRUE} setting is only for backward compatibility with RJSONIO, and a message will be printed each time a named vector is encountered.
+This option will stop being supported in a future version of jsonlite.}
 }
 \description{
 These functions are used to convert between JSON data and \R{} objects. The \code{\link{toJSON}} and \code{\link{fromJSON}}


### PR DESCRIPTION
This PR fixes #76.

It adds the `keep_vec_names` option, which, when TRUE, tells `asJSON` to convert named vectors to JSON objects, instead of the default arrays.

It also prints out an annoying message, encouraging people to use named lists instead.

```R
jsonlite::toJSON(c(a=1), keep_vec_names=TRUE)
# Input to asJSON(keep_vec_names=TRUE) is a named vector.
# In a future version of jsonlite, this option will not be supported,
# and named vectors will be translated into arrays instead of objects.
# If you want JSON object output, please use a named list instead. See ?toJSON.
# {"a":1} 
```

I needed to special cases factors so that they preserved names, to be passed on to `asJSON.character`. Other non-basic vector types (Dates, POSIXct, etc) didn't seem to need this.