### PR TITLE
Do not encode values returned from toJSON()

### DIFF
--- a/R/asJSON.json.R
+++ b/R/asJSON.json.R
@@ -1,0 +1,4 @@
+# If an object has already been encoded by toJSON(), do not encode it again
+setMethod("asJSON", "json", function(x, ...) {
+  x
+})


### PR DESCRIPTION
This will be very helpful for us to solve the problem in https://github.com/ramnathv/htmlwidgets/pull/28. Basically it means `toJSON(toJSON(x)) == toJSON(x)`.

If someone really wants to double-encode the JSON string, he/she could do `toJSON(as.character(toJSON(x)))`.

Please let me know what you think. Thanks!

