### PR TITLE
Make toJSON() extensible on other classes

### DIFF
--- a/R/asJSON.ANY.R
+++ b/R/asJSON.ANY.R
@@ -17,6 +17,8 @@ setMethod("asJSON", "ANY", function(x, force = FALSE, ...) {
   } else if (isTRUE(force)) {
     return(asJSON(NULL))
     warning("No method asJSON S3 class: ", class(x))
+  } else if (is.function(force)) {
+    force(x, ...)
   } else {
     # If even that doesn't work, we give up.
     stop("No method asJSON S3 class: ", class(x))


### PR DESCRIPTION
Here is an alternative attempt (and more general) to solve the problem in ramnathv/htmlwidgets#28. When the class is unknown to `asJSON()`, we can use `force` as a function to decide what we want to do with this object. In the case of `json`, we (e.g. htmlwidgets/shiny authors/users) can

```r
toJSON(x, force = function(x, ...) {
  if (inherits(x, 'json')) return(x)
  stop('Unknown class ', class(x))
})
```
