### PR TITLE
Filtered page saved to new variable in stream_in

### DIFF
--- a/R/stream.R
+++ b/R/stream.R
@@ -158,8 +158,8 @@ stream_in <- function(con, handler = NULL, pagesize = 500, verbose = TRUE, ...) 
   repeat {
     page <- readLines(con, n = pagesize, encoding = "UTF-8")
     if(length(page)){
-      page <- Filter(nchar, page)
-      cb(lapply(page, parseJSON))
+      cleanpage <- Filter(nchar, page)
+      cb(lapply(cleanpage, parseJSON))
       if(verbose)
         cat("\r Found", count, "records...")
     }


### PR DESCRIPTION
In the streaming context (using `stream_in`), empty lines in 'full' pages (# lines `== pagesize`) of JSON input were inhibiting 'reading in' of subsequent pages from the same JSON file.  Specifically, the act of filtering out empty lines was causing page length to shorten such that it became less than `pagesize` prior to checking if the loop should read another page. The fix implemented here keeps `page` untouched and instead saves the filtered page to a new variable, `cleanpage`.