### PR TITLE
Potential fix of modp_numtoa.c to resolve #148

### DIFF
--- a/src/modp_numtoa.c
+++ b/src/modp_numtoa.c
@@ -179,6 +179,7 @@ void modp_dtoa(double value, char* str, int prec)
 //   The differnce is noted below
 void modp_dtoa2(double value, char* str, int prec)
 {
+
     /* Hacky test for NaN
      * under -fast-math this won't work, but then you also won't
      * have correct nan values anyways.  The alternative is
@@ -229,6 +230,15 @@ void modp_dtoa2(double value, char* str, int prec)
         /* if halfway, round up if odd, OR
            if last digit is 0.  That last part is strange */
         ++frac;
+    }
+
+    /* solves issue #148
+     * in the case where diff == 0.5 and x < 1
+     * e.g. 0.99995 with prec 4
+     */
+    if (frac == poww10[prec]) {
+      sprintf(str, "%.*f", prec, (double) ++whole);
+      return;
     }
 
     /* for very large numbers switch back to native sprintf for exponentials.

--- a/src/modp_numtoa.c
+++ b/src/modp_numtoa.c
@@ -237,7 +237,7 @@ void modp_dtoa2(double value, char* str, int prec)
      * e.g. 0.99995 with prec 4
      */
     if (frac == poww10[prec]) {
-      sprintf(str, "%.*f", prec, (double) ++whole);
+      sprintf(str, "%.*f", prec, neg ? -(double) ++whole : (double) ++whole);
       return;
     }
 

--- a/tests/testthat/test-toJSON-numeric.R
+++ b/tests/testthat/test-toJSON-numeric.R
@@ -43,4 +43,10 @@ test_that("Force decimal works", {
   # always_decimal makes sure that doubles stay real
   y2 <- fromJSON(toJSON(x1, digits = 9, always_decimal = TRUE), simplifyVector = FALSE)
   expect_identical(as.list(x1), y2)
+
+  # as per #148, ensure rounding of 0.999x works correctly
+  expect_equal(toJSON(0.995, digits = 2), "[1.00]")
+  expect_equal(toJSON(0.9995, digits = 3), "[1.000]")
+  expect_equal(toJSON(0.99995, digits = 4), "[1.0000]")
+  expect_equal(toJSON(1.99995, digits = 4), "[1.9999]")
 })

--- a/tests/testthat/test-toJSON-numeric.R
+++ b/tests/testthat/test-toJSON-numeric.R
@@ -49,4 +49,5 @@ test_that("Force decimal works", {
   expect_equal(toJSON(0.9995, digits = 3), "[1.000]")
   expect_equal(toJSON(0.99995, digits = 4), "[1.0000]")
   expect_equal(toJSON(1.99995, digits = 4), "[1.9999]")
+  expect_equal(toJSON(-1.99995, digits = 4), "[-1.9999]")
 })


### PR DESCRIPTION
I'm not suggesting this is the best way to resolve this one, but it appears to work. By all means, if this doesn't do what you're hoping then feel free to disregard. I took this as a useful exercise in strengthening my `C++` skills.

Passes all tests (including new ones added specific to #148).

Some possibly unexpected (or expected?) behaviour regarding the difference between rounding of values `< 1` and those `> 1`.

### Commit messages:
closes #148 by checking for the round-up condition explicitly
adds tests for same