### PR TITLE
jeroenooms/mongolite#45

### DIFF
--- a/R/asJSON.POSIXt.R
+++ b/R/asJSON.POSIXt.R
@@ -14,7 +14,7 @@ setMethod("asJSON", "POSIXt", function(x, POSIXt = c("string", "ISO8601", "epoch
     df <- data.frame("$date" = floor(unclass(x) * 1000), check.names = FALSE)
     if(inherits(x, "scalar"))
       class(df) <- c("scalar", class(df))
-    return(asJSON(df, digits = 0, always_decimal = FALSE, ...))
+    return(asJSON(df, digits = NA, always_decimal = FALSE, ...))
   }
 
   # Epoch millis


### PR DESCRIPTION
This change fixes jeroenooms/mongolite#45.

For some reason POSIXt datetimes before the epoch are getting converted to JSON in scientific notation (whereas POSIXt datetimes after the epoch are not converted to scientific notation). This only appears when using the POSIXt = "mongo" option. I'm not familiar enough with the R numerical data type implementation to understand why this happens, but I couldn't fix it in my code.

When the pre-epoch negative timestamps in scientific notation are getting passed to the mongo c library, it results in the error "Error: Invalid read of double in state 4" Changing the digits option in the asJSON.POSIXt method from digits=0 to digits=NA allows for arbitrary precision and fixes this problem.

Since digits=0 is hardcoded for asJSON.POSIXt(POSIXt = "mongo"), there is no way to fix this in client code that uses mongolite without making this change in jsonlite. I tested this change in my code and I can confirm that it now allows for insertion of pre-1970 POSIXt dates into MongoDB.