### PR TITLE
Handle missing input consistently

### DIFF
--- a/R/fromJSON.R
+++ b/R/fromJSON.R
@@ -77,6 +77,8 @@
 fromJSON <- function(txt, simplifyVector = TRUE, simplifyDataFrame = simplifyVector,
   simplifyMatrix = simplifyVector, flatten = FALSE, ...) {
 
+  # empty JSON -> empty data.frame
+  if (is.na(txt) || is.null(txt)) return(data.frame(NULL))
   # check type
   if (!is.character(txt) && !inherits(txt, "connection")) {
     stop("Argument 'txt' must be a JSON string, URL or file.")


### PR DESCRIPTION
Closes #211

This allows the following syntax to work without error:

```
DF = data.frame(json = c('{"hey": 1, "you": 2}', NA_character_, '{"hey": 3, "you": 4}', stringsAsFactors = FALSE)
do.call(rbind, lapply(DF$json, fromJSON))
#    hey you
# 2    1   2
# 21   3   4
```